### PR TITLE
Added support for Markdown files

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -57,6 +57,7 @@ const supportedLang: string[] = [
     "kt", // Kotlin
     "lua", // Lua
     "mjs", // Javascript
+    "md", // HTML
     "php", // PHP
     "pl", // Perl
     "py", // Python
@@ -147,6 +148,7 @@ const cmtSyntaxDouble: {
     [key: string]: DoubleLineCommentSyntax;
 } = {
     html: { first: "<!-- ", last: " -->" },
+    md: { first: "<!-- ", last: " -->" },
     twig: { first: "{# ", last: " #}" },
     blade: { first: "{{-- ", last: " --}}" },
     hbs: { first: "{{!-- ", last: " --}}" },

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,7 +57,7 @@ const supportedLang: string[] = [
     "kt", // Kotlin
     "lua", // Lua
     "mjs", // Javascript
-    "md", // HTML
+    "md", // Markdown
     "php", // PHP
     "pl", // Perl
     "py", // Python


### PR DESCRIPTION
All I did was copy the code defining HTML comments and use it for Markdown, then I updated the supported languages.